### PR TITLE
Fixes ProximityContent swift example

### DIFF
--- a/Examples/swift/ProximityContent/ProximityContent/Estimote/NearestBeaconManager.swift
+++ b/Examples/swift/ProximityContent/ProximityContent/Estimote/NearestBeaconManager.swift
@@ -4,7 +4,7 @@
 
 protocol NearestBeaconManagerDelegate: class {
 
-    func nearestBeaconManager(_ nearestBeaconManager: NearestBeaconManager, didUpdateNearestBeaconID nearestBeaconID: BeaconID?)
+    func nearestBeaconManager(_ nearestBeaconManager: NearestBeaconManager, didUpdateNearestBeacon nearestBeacon: CLBeacon?)
 
 }
 
@@ -46,7 +46,7 @@ class NearestBeaconManager: NSObject, ESTBeaconManagerDelegate {
 
         if nearestBeacon?.beaconID != self.nearestBeaconID || !firstEventSent {
             self.nearestBeaconID = nearestBeacon?.beaconID
-            self.delegate?.nearestBeaconManager(self, didUpdateNearestBeaconID: self.nearestBeaconID)
+            self.delegate?.nearestBeaconManager(self, didUpdateNearestBeacon: nearestBeacon)
             self.firstEventSent = true
         }
     }

--- a/Examples/swift/ProximityContent/ProximityContent/Estimote/ProximityContentManager.swift
+++ b/Examples/swift/ProximityContent/ProximityContent/Estimote/ProximityContentManager.swift
@@ -35,9 +35,9 @@ class ProximityContentManager: NearestBeaconManagerDelegate {
         self.nearestBeaconManager.stopNearestBeaconUpdates()
     }
 
-    func nearestBeaconManager(_ nearestBeaconManager: NearestBeaconManager, didUpdateNearestBeaconID nearestBeaconID: BeaconID?) {
-        if let nearestBeaconID = nearestBeaconID {
-            self.beaconContentFactory.requestContent(for: nearestBeaconID) { (proximityContent) in
+    func nearestBeaconManager(_ nearestBeaconManager: NearestBeaconManager, didUpdateNearestBeacon nearestBeacon: CLBeacon?) {
+        if let nearestBeacon = nearestBeacon {
+            self.beaconContentFactory.requestContent(for: nearestBeacon) { (proximityContent) in
                 self.delegate?.proximityContentManager(self, didUpdateContent: proximityContent)
             }
         } else {


### PR DESCRIPTION
BeaconContentFactory uses the CLBeacon rather than the BeaconID